### PR TITLE
chore: format and add note to xtp.toml template

### DIFF
--- a/template/xtp.toml.ejs
+++ b/template/xtp.toml.ejs
@@ -3,15 +3,16 @@ app_id = "<%= project.appId %>"
 # This is where 'xtp plugin push' expects to find the wasm file after the build script has run.
 bin = "dist/plugin.wasm"
 extension_point_id = "<%= project.extensionPointId %>"
+
+# This is the 'binding' name used for the plugin.
 name = "<%= project.name %>"
 
 [scripts]
+# xtp plugin build runs this script to generate the wasm file
+build = "npm run build"
 
-  # xtp plugin build runs this script to generate the wasm file
-  build = "npm run build"
+# xtp plugin init runs this script to format the code
+format = "npm run format"
 
-  # xtp plugin init runs this script to format the code
-  format = "npm run format"
-
-  # xtp plugin init runs this script before running the format script
-  prepare = "npm install"
+# xtp plugin init runs this script before running the format script
+prepare = "npm install"


### PR DESCRIPTION
Removes the indentation under the `[scripts]` block and adds a note about the `name` property as it relates to the "binding" name in docs and the API.

