### PR TITLE
Support "Number"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "xtp-typescript-bindgen",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "xtp-typescript-bindgen",
-      "version": "0.0.8",
+      "version": "0.0.9",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dylibso/xtp-bindgen": "^0.0.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xtp-typescript-bindgen",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "XTP TypeScript bindgen plugin",
   "main": "dist/index.js",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,9 @@ function toTypeScriptType(property: Property): string {
     case "string":
       return "string"
     case "integer":
+      if (property.format === 'int64') throw Error(`We do not support format int64 yet`)
+      return "number"
+    case "number":
       return "number"
     case "boolean":
       return "boolean"


### PR DESCRIPTION
Addresses #4 

From what i can tell, I think the format specifier shouldn't make a difference for floats. For ints we may need to make a BigInt. But i'm not ready to support that yet as we're only supporting what cleanly maps to json at the moment. I'm going to ticket up and work out a system to auto map things like dates to and from json. At that point we can support BigInts.