### PR TITLE
fix: handle case when no code samples are available

### DIFF
--- a/bundle.sh
+++ b/bundle.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-npm run build
+npm i && npm run build
 
 rm -rf bundle
 mkdir bundle

--- a/template/src/main.ts.ejs
+++ b/template/src/main.ts.ejs
@@ -28,7 +28,7 @@ import {
  */
 <% -%>
 export function <%= ex.name %>Impl(<%- ex.input ? `input: ${toTypeScriptType(ex.input)}`: null %>)<%- ex.output ? `:${toTypeScriptType(ex.output)}` : null %> {
-<% if (featureFlags['stub-with-code-samples']) { -%>
+<% if (featureFlags['stub-with-code-samples'] && codeSamples(ex, 'typescript').length > 0) { -%>
 <%- codeSamples(ex, 'typescript')[0].source %>
 <% } else { -%>
   // TODO: fill out your implementation here


### PR DESCRIPTION
Just defaults to the "unimplemented" case if no code samples are in the schema.