### PR TITLE
Add support for base64 encoded buffer properties

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,8 @@ function needsCasting(p: Property | Parameter): boolean {
   if (p.$ref) return true
 
   switch (p.type) {
+    case "buffer":
+      return true
     case "string":
       if (p.format === 'date-time') return true
       return false
@@ -61,11 +63,17 @@ function toTypeScriptType(property: Property | Parameter): string {
   return `${tp} | null`
 }
 
+// TODO: can move this helper up to shared library?
+function isBuffer(property: Property | Parameter): boolean {
+  return property.type === 'buffer'
+}
+
 export function render() {
   const tmpl = Host.inputString()
   const ctx = {
     ...getContext(),
     ...helpers,
+    isBuffer,
     toTypeScriptType,
     needsCasting,
   }

--- a/template/src/pdk.ts.ejs
+++ b/template/src/pdk.ts.ejs
@@ -27,8 +27,10 @@ export class <%- schema.name %> {
         <% if (needsCasting(p)) { -%>
           <% if (isDateTime(p)) { -%>
             <%- p.name -%>: obj.<%- p.name -%> ? new Date(obj.<%- p.name -%>) : null,
+          <% } else if (isBuffer(p)) {-%>
+            <%- p.name -%>: obj.<%- p.name -%> ? Host.base64ToArrayBuffer(obj.<%- p.name -%>) : null,
           <% } else if (!isPrimitive(p)) {-%>
-            <%- p.name -%>: obj.<%- p.name -%> ? <%- p.$ref.name %>.fromJson(obj.<%- p.name %>) : null,
+            <%- p.name -%>: obj.<%- p.name -%> ? <%- p.$ref.name %>.fromJson(obj.<%- p.name -%>) : null,
           <% } -%>
         <% } -%>
       <% }) -%>
@@ -42,8 +44,10 @@ export class <%- schema.name %> {
         <% if (needsCasting(p)) { -%>
           <% if (p.type === "string" && p.format === "date-time") { -%>
             <%- p.name -%>: obj.<%- p.name -%> ? obj.<%- p.name %>.toISOString() : null,
+          <% } else if (isBuffer(p)) {-%>
+            <%- p.name -%>: obj.<%- p.name -%> ? Host.arrayBufferToBase64(obj.<%- p.name -%>) : null,
           <% } else if (p.$ref && !p.$ref.enum) {-%>
-            <%- p.name -%>: obj.<%- p.name -%> ? <%- p.$ref.name %>.toJson(obj.<%- p.name %>) : null,
+            <%- p.name -%>: obj.<%- p.name -%> ? <%- p.$ref.name %>.toJson(obj.<%- p.name -%>) : null,
           <% } -%>
         <% } -%>
       <% }) -%>


### PR DESCRIPTION
Base64 encodes/decodes json properties that are buffers at the transport layer. Still need to add support for top-level.