### PR TITLE
Fix param jsdoc formatting

### DIFF
--- a/template/src/main.ts.ejs
+++ b/template/src/main.ts.ejs
@@ -20,7 +20,7 @@ import {
  * <%- formatCommentBlock(ex.description) %>
  *
 <% if (hasComment(ex.input)) { -%>
- * @param input {<%- toTypeScriptType(ex.input) %>} <%- formatCommentLine(ex.input.description) %>
+ * @param {<%- toTypeScriptType(ex.input) %>} input - <%- formatCommentLine(ex.input.description) %>
 <% } -%>
 <% if (hasComment(ex.output)) { -%>
  * @returns {<%- toTypeScriptType(ex.output) %>} <%- formatCommentLine(ex.output.description) %>

--- a/template/src/pdk.ts.ejs
+++ b/template/src/pdk.ts.ejs
@@ -71,7 +71,7 @@ export enum <%- schema.name %> {
  * <%- formatCommentBlock(imp.description) %>
  *
 <% if (hasComment(imp.input)) { -%>
- * @param input {<%- toTypeScriptType(imp.input) %>} <%- formatCommentLine(imp.input.description) %>
+ * @param {<%- toTypeScriptType(imp.input) %>} input - <%- formatCommentLine(imp.input.description) %>
 <% } -%>
 <% if (hasComment(imp.output)) { -%>
  * @returns {<%- toTypeScriptType(imp.output) %>} <%- formatCommentLine(imp.output.description) %>


### PR DESCRIPTION
The parameter name should follow the type, not precede it. And we can use a hyphen to delineate the name and the description

https://jsdoc.app/tags-param