### PR TITLE
Preserve undefined vs null in encoders

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,7 @@ jobs:
 
       - name: Setup Extism
         run: |
-          curl -O https://raw.githubusercontent.com/extism/js-pdk/main/install.sh
-          sh install.sh
+          curl -L https://raw.githubusercontent.com/extism/js-pdk/main/install.sh | bash
 
       - name: Set up Node.js
         uses: actions/setup-node@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,9 +15,8 @@ jobs:
 
       - name: Setup Extism and XTP
         run: |
-          curl -O https://raw.githubusercontent.com/extism/js-pdk/main/install.sh
-          sh install.sh
-          curl https://static.dylibso.com/cli/install.sh | sh
+          curl https://raw.githubusercontent.com/extism/js-pdk/main/install.sh | bash
+          curl https://static.dylibso.com/cli/install.sh | bash
 
       - name: Set up Node.js
         uses: actions/setup-node@v3

--- a/template/src/pdk.ts.ejs
+++ b/template/src/pdk.ts.ejs
@@ -25,11 +25,11 @@ export class <%- schema.name %> {
       ...obj,
       <% schema.properties.forEach(p => { -%>
         <% if (isDateTime(p)) { -%>
-          <%- p.name -%>: obj.<%- p.name -%> ? new Date(obj.<%- p.name -%>) : null,
+          <%- p.name -%>: obj.<%- p.name -%> == null ? obj.<%- p.name %> : new Date(obj.<%- p.name -%>),
         <% } else if (isBuffer(p)) {-%>
-          <%- p.name -%>: obj.<%- p.name -%> ? Host.base64ToArrayBuffer(obj.<%- p.name -%>) : null,
+          <%- p.name -%>: obj.<%- p.name -%> == null ? obj.<%- p.name %> : Host.base64ToArrayBuffer(obj.<%- p.name -%>),
         <% } else if (!isPrimitive(p)) {-%>
-          <%- p.name -%>: obj.<%- p.name -%> ? <%- p.$ref.name %>.fromJson(obj.<%- p.name -%>) : null,
+          <%- p.name -%>: obj.<%- p.name -%> == null ? obj.<%- p.name %> : <%- p.$ref.name %>.fromJson(obj.<%- p.name -%>),
         <% } -%>
       <% }) -%>
     }
@@ -40,11 +40,11 @@ export class <%- schema.name %> {
       ...obj,
       <% schema.properties.forEach(p => { -%>
         <% if (p.type === "string" && p.format === "date-time") { -%>
-          <%- p.name -%>: obj.<%- p.name -%> ? obj.<%- p.name %>.toISOString() : null,
+          <%- p.name -%>: obj.<%- p.name -%> == null ? obj.<%- p.name %> : obj.<%- p.name %>.toISOString(),
         <% } else if (isBuffer(p)) {-%>
-          <%- p.name -%>: obj.<%- p.name -%> ? Host.arrayBufferToBase64(obj.<%- p.name -%>) : null,
+          <%- p.name -%>: obj.<%- p.name -%> == null ? obj.<%- p.name %> : Host.arrayBufferToBase64(obj.<%- p.name -%>),
         <% } else if (p.$ref && !p.$ref.enum) {-%>
-          <%- p.name -%>: obj.<%- p.name -%> ? <%- p.$ref.name %>.toJson(obj.<%- p.name -%>) : null,
+          <%- p.name -%>: obj.<%- p.name -%> == null ? obj.<%- p.name %>: <%- p.$ref.name %>.toJson(obj.<%- p.name -%>) ,
         <% } -%>
       <% }) -%>
     }

--- a/template/src/pdk.ts.ejs
+++ b/template/src/pdk.ts.ejs
@@ -25,11 +25,11 @@ export class <%- schema.name %> {
       ...obj,
       <% schema.properties.forEach(p => { -%>
         <% if (isDateTime(p)) { -%>
-          <%- p.name -%>: obj.<%- p.name -%> == null ? obj.<%- p.name %> : new Date(obj.<%- p.name -%>),
+          <%- p.name -%>: obj.<%- p.name -%> === undefined || obj.<%- p.name -%> === null ? obj.<%- p.name %> : new Date(obj.<%- p.name -%>),
         <% } else if (isBuffer(p)) {-%>
-          <%- p.name -%>: obj.<%- p.name -%> == null ? obj.<%- p.name %> : Host.base64ToArrayBuffer(obj.<%- p.name -%>),
+          <%- p.name -%>: obj.<%- p.name -%> === undefined || obj.<%- p.name -%> === null ? obj.<%- p.name %> : Host.base64ToArrayBuffer(obj.<%- p.name -%>),
         <% } else if (!isPrimitive(p)) {-%>
-          <%- p.name -%>: obj.<%- p.name -%> == null ? obj.<%- p.name %> : <%- p.$ref.name %>.fromJson(obj.<%- p.name -%>),
+          <%- p.name -%>: obj.<%- p.name -%> === undefined || obj.<%- p.name -%> === null ? obj.<%- p.name %> : <%- p.$ref.name %>.fromJson(obj.<%- p.name -%>),
         <% } -%>
       <% }) -%>
     }
@@ -40,11 +40,11 @@ export class <%- schema.name %> {
       ...obj,
       <% schema.properties.forEach(p => { -%>
         <% if (p.type === "string" && p.format === "date-time") { -%>
-          <%- p.name -%>: obj.<%- p.name -%> == null ? obj.<%- p.name %> : obj.<%- p.name %>.toISOString(),
+          <%- p.name -%>: obj.<%- p.name -%> === undefined || obj.<%- p.name -%> === null ? obj.<%- p.name %> : obj.<%- p.name %>.toISOString(),
         <% } else if (isBuffer(p)) {-%>
-          <%- p.name -%>: obj.<%- p.name -%> == null ? obj.<%- p.name %> : Host.arrayBufferToBase64(obj.<%- p.name -%>),
+          <%- p.name -%>: obj.<%- p.name -%> === undefined || obj.<%- p.name -%> === null ? obj.<%- p.name %> : Host.arrayBufferToBase64(obj.<%- p.name -%>),
         <% } else if (p.$ref && !p.$ref.enum) {-%>
-          <%- p.name -%>: obj.<%- p.name -%> == null ? obj.<%- p.name %>: <%- p.$ref.name %>.toJson(obj.<%- p.name -%>) ,
+          <%- p.name -%>: obj.<%- p.name -%> === undefined || obj.<%- p.name -%> === null ? obj.<%- p.name %>: <%- p.$ref.name %>.toJson(obj.<%- p.name -%>) ,
         <% } -%>
       <% }) -%>
     }


### PR DESCRIPTION
In the json encoder / decoder, we were essentially re-writing undefineds with null. This should preserve the value as null or undefined in the falsey case.

```
> x = undefined
> 
> x == null ? x : x.toString()
> 
> x = null
> null
> x == null ? x : x.toString()
> null
> x = 123
> 123
> x == null ? x : x.toString()
> '123'
```

