### PR TITLE
fix: dont remove imports

### DIFF
--- a/template/package.json.ejs
+++ b/template/package.json.ejs
@@ -5,7 +5,7 @@
   "main": "src/index.ts",
   "scripts": {
     "build": "npx tsc --noEmit && node esbuild.js && extism-js dist/index.js -i src/index.d.ts -o dist/plugin.wasm",
-    "format": "npx prettier --write \"src/**/*.{ts,tsx}\" --plugin=prettier-plugin-organize-imports"
+    "format": "npx prettier --write \"src/**/*.{ts,tsx}\""
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
This undoes #32 because it seems like it doesn't respect imports by the code snippets, maybe we can bring it back after we find a solution for that. See https://github.com/dylibso/xtp/pull/859#issuecomment-2427346138