### PR TITLE
Refactor Bindgen

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.15",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@dylibso/xtp-bindgen": "1.0.0-rc.11",
+        "@dylibso/xtp-bindgen": "1.0.0-rc.13",
         "ejs": "^3.1.10"
       },
       "devDependencies": {
@@ -21,9 +21,9 @@
       }
     },
     "node_modules/@dylibso/xtp-bindgen": {
-      "version": "1.0.0-rc.11",
-      "resolved": "https://registry.npmjs.org/@dylibso/xtp-bindgen/-/xtp-bindgen-1.0.0-rc.11.tgz",
-      "integrity": "sha512-zXesPfNHKaEK3IwMKFW5qk4UoJTazxmslpyUYn6n4FffZvY7QPBOSomyNVaNRtTr3ziz5SwF2RAm+Rken21HIg=="
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@dylibso/xtp-bindgen/-/xtp-bindgen-1.0.0-rc.13.tgz",
+      "integrity": "sha512-aCmYSgC3Xwdlhm8mBKVpkzuHAtQ84ZgIwkdYQ3QFmDRxnBlZUtOZgpRoJTtOnahm0lUCiBkWkLcsikUluMY/qw=="
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.19.12",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.15",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@dylibso/xtp-bindgen": "1.0.0-rc.13",
+        "@dylibso/xtp-bindgen": "1.0.0-rc.15",
         "ejs": "^3.1.10"
       },
       "devDependencies": {
@@ -21,9 +21,9 @@
       }
     },
     "node_modules/@dylibso/xtp-bindgen": {
-      "version": "1.0.0-rc.13",
-      "resolved": "https://registry.npmjs.org/@dylibso/xtp-bindgen/-/xtp-bindgen-1.0.0-rc.13.tgz",
-      "integrity": "sha512-aCmYSgC3Xwdlhm8mBKVpkzuHAtQ84ZgIwkdYQ3QFmDRxnBlZUtOZgpRoJTtOnahm0lUCiBkWkLcsikUluMY/qw=="
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@dylibso/xtp-bindgen/-/xtp-bindgen-1.0.0-rc.15.tgz",
+      "integrity": "sha512-8Z+5L/HAgzB4M6VYW6BTL+0E2zU3FSAvI0kRZUebcTsnOXzA60br7cYjIW8x58SuvqlCeA6ZK+1FOBCJBzxZkQ=="
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.19.12",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "typescript": "^5.3.2"
   },
   "dependencies": {
-    "@dylibso/xtp-bindgen": "1.0.0-rc.13",
+    "@dylibso/xtp-bindgen": "1.0.0-rc.15",
     "ejs": "^3.1.10"
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "typescript": "^5.3.2"
   },
   "dependencies": {
-    "@dylibso/xtp-bindgen": "1.0.0-rc.11",
+    "@dylibso/xtp-bindgen": "1.0.0-rc.13",
     "ejs": "^3.1.10"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import ejs from 'ejs'
-import { helpers, getContext, ObjectType, EnumType, ArrayType, XtpNormalizedType, MapType, Parameter, Property } from "@dylibso/xtp-bindgen"
+import { helpers, getContext, ObjectType, EnumType, ArrayType, XtpNormalizedType, MapType, XtpTyped } from "@dylibso/xtp-bindgen"
 
 function toTypeScriptTypeX(type: XtpNormalizedType): string {
   // annotate with null if nullable 
@@ -40,8 +40,6 @@ function toTypeScriptTypeX(type: XtpNormalizedType): string {
       throw new Error("Cant convert property to typescript type: " + JSON.stringify(type))
   }
 }
-
-type XtpTyped = { xtpType: XtpNormalizedType }
 
 function toTypeScriptType(property: XtpTyped): string {
   return toTypeScriptTypeX(property.xtpType!)

--- a/template/src/index.ts.ejs
+++ b/template/src/index.ts.ejs
@@ -13,11 +13,11 @@ export function <%- ex.name %>(): number {
     <% if (isJsonEncoded(ex.input)) { -%>
       <% if (isBuffer(ex.input)) { -%>
         const input: <%- toTypeScriptType(ex.input) %> = Host.base64ToArrayBuffer(JSON.parse(Host.inputString()))
-      <% } else if (isPrimitive(ex.input)) { -%>
-        const input: <%- toTypeScriptType(ex.input) %> = JSON.parse(Host.inputString())
-      <% } else { -%>
+      <% } else if (isObject(ex.input)) { -%>
         const untypedInput = JSON.parse(Host.inputString())
         const input = <%- toTypeScriptType(ex.input) %>.fromJson(untypedInput)
+      <% } else { -%>
+        const input: <%- toTypeScriptType(ex.input) %> = JSON.parse(Host.inputString())
       <% } -%>
     <% } else if (ex.input.type === 'string') { -%>
       const input = Host.inputString() <%- (ex.input.$ref && ex.input.$ref.enum) ? `as ${ex.input.$ref.name}` : "" %>
@@ -42,11 +42,11 @@ export function <%- ex.name %>(): number {
     <% if (isJsonEncoded(ex.output)) { -%>
       <% if (isBuffer(ex.output)) { -%>
         Host.outputString(JSON.stringify(Host.arrayBufferToBase64(output)))
-      <% } else if (isPrimitive(ex.output)) { -%>
-        Host.outputString(JSON.stringify(output))
-      <% } else { -%>
+      <% } else if (isObject(ex.output)) { -%>
         const untypedOutput = <%- toTypeScriptType(ex.output) %>.toJson(output)
         Host.outputString(JSON.stringify(untypedOutput))
+      <% } else { -%>
+        Host.outputString(JSON.stringify(output))
       <% } -%>
     <% } else if (ex.output.type === 'string') { -%>
       Host.outputString(output)

--- a/template/src/pdk.ts.ejs
+++ b/template/src/pdk.ts.ejs
@@ -8,21 +8,45 @@ function isNull(v: any): boolean {
 
 function cast(caster: (v: any) => any, v: any): any {
   if (isNull(v)) return v
-  if (Array.isArray(v)) return v.map(caster)
   return caster(v)
 }
 
-function dateToJson(v: Date): string {
+function castArray(caster: (v: any) => any) {
+  return (v?: Array<any>) => {
+    if (isNull(v)) return v
+    caster = cast.bind(null, caster) // bind to null-preserving logic in `cast`
+    return v!.map(caster)
+  }
+}
+
+function castMap(caster: (v: any) => any) {
+  return (v?: any) => {
+    if (isNull(v)) return v
+
+    caster = cast.bind(null, caster) // bind to null-preserving logic in `cast`
+    const newMap: any = {}
+    for (const k in v) {
+      newMap[k] = caster(v![k])
+    }
+    return newMap
+  }
+}
+
+function dateToJson(v?: Date): string | undefined | null {
+  if (v === undefined || v === null) return v
   return v.toISOString()
 }
-function dateFromJson(v: string): Date {
+function dateFromJson(v?: string): Date | undefined | null {
+  if (v === undefined || v === null) return v
   return new Date(v)
 }
 
-function bufferToJson(v: ArrayBuffer): string {
+function bufferToJson(v?: ArrayBuffer): string | undefined | null {
+  if (v === undefined || v === null) return v
   return Host.arrayBufferToBase64(v)
 }
-function bufferFromJson(v: string): ArrayBuffer {
+function bufferFromJson(v?: string): ArrayBuffer | undefined | null {
+  if (v === undefined || v === null) return v
   return Host.base64ToArrayBuffer(v)
 }
 
@@ -48,14 +72,8 @@ export class <%- schema.name %> {
     return {
       ...obj,
       <% schema.properties.forEach(p => { -%>
-        <% let baseP = p.items ? p.items : p -%>
-        <% let baseRef = p.$ref ? p.$ref.name : (p.items && p.items.$ref ? p.items.$ref.name : null)  -%>
-        <% if (isDateTime(baseP)) { -%>
-          <%- p.name -%>: cast(dateFromJson, obj.<%- p.name -%>),
-        <% } else if (isBuffer(baseP)) {-%>
-          <%- p.name -%>: cast(bufferFromJson, obj.<%- p.name -%>),
-        <% } else if (!isPrimitive(baseP)) {-%>
-          <%- p.name -%>: cast(<%- baseRef -%>.fromJson, obj.<%- p.name -%>),
+        <% if (isCastable(p.xtpType)) { -%>
+          <%- p.name -%>: cast(<%- castExpression(p.xtpType, 'From') %>, obj.<%- p.name %>),
         <% } -%>
       <% }) -%>
     }
@@ -65,26 +83,20 @@ export class <%- schema.name %> {
     return {
       ...obj,
       <% schema.properties.forEach(p => { -%>
-        <% let baseP = p.items ? p.items : p -%>
-        <% let baseRef = p.$ref ? p.$ref.name : (p.items && p.items.$ref ? p.items.$ref.name : null)  -%>
-        <% if (isDateTime(baseP)) { -%>
-          <%- p.name -%>: cast(dateToJson, obj.<%- p.name -%>),
-        <% } else if (isBuffer(baseP)) {-%>
-          <%- p.name -%>: cast(bufferToJson, obj.<%- p.name -%>),
-        <% } else if (!isPrimitive(baseP)) {-%>
-          <%- p.name -%>: cast(<%- baseRef -%>.toJson, obj.<%- p.name -%>),
+        <% if (isCastable(p.xtpType)) { -%>
+          <%- p.name -%>: cast(<%- castExpression(p.xtpType, 'To') %>, obj.<%- p.name %>),
         <% } -%>
       <% }) -%>
     }
   }
 }
-  <% } else if (schema.enum) { %>
+  <% } else if (isEnum(schema)) { %>
 
 /**
  * <%- formatCommentLine(schema.description) %>
  */
 export enum <%- schema.name %> {
-  <% schema.enum.forEach(variant => { -%>
+  <% schema.xtpType.values.forEach(variant => { -%>
     <%- variant
         // "host:foo$bar" -> "host_Foo$bar"
         .replace(/[^a-zA-Z0-9_$]+(.)?/g, (a, m) => '_' + (m ||'').toUpperCase())
@@ -115,15 +127,16 @@ export enum <%- schema.name %> {
 export function <%- imp.name %>(<%- imp.input ? `input: ${toTypeScriptType(imp.input)}` : null %>) <%- imp.output ? `:${toTypeScriptType(imp.output)}` : null %> {
 <% if (imp.input) { -%>
   <% if (isJsonEncoded(imp.input)) { -%>
-    <% if (isPrimitive(imp.input)) { %>
-      const mem = Memory.fromJsonObject(input as any)
-    <% } else { %>
-      const casted = <%- toTypeScriptType(imp.input) %>.toJson(input)
+    <% if (isObject(imp.input)) { %>
+      // we need to cast the input back into a json encodable form
+      const casted = cast(<%- castExpression(imp.input.xtpType, 'To') %>, input)
       const mem = Memory.fromJsonObject(casted)
+    <% } else { %>
+      const mem = Memory.fromJsonObject(input as any)
     <% } %>
   <% } else if (isUtf8Encoded(imp.input)) { -%>
   const mem = Memory.fromString(input as string)
-  <% } else if (imp.input.type === 'string') { -%>
+  <% } else if (isString(imp.input.type)) { -%>
   const mem = Memory.fromString(input)
   <% } else { -%>
   const mem = Memory.fromBuffer(input)
@@ -136,15 +149,16 @@ export function <%- imp.name %>(<%- imp.input ? `input: ${toTypeScriptType(imp.i
 
 <% if (imp.output) { -%>
   <% if (isJsonEncoded(imp.output)) { -%>
-    <% if (isPrimitive(imp.output)) { -%>
-      return Memory.find(ptr).readJsonObject();
-    <% } else { -%>
+    <% if (isObject(imp.output)) { -%>
+      // we need to cast the output back from its json encodable form
       const output = Memory.find(ptr).readJsonObject();
-      return <%- toTypeScriptType(imp.output) %>.fromJson(output)
+      return cast(<%- castExpression(imp.output.xtpType, 'From') %>, output)
+    <% } else { -%>
+      return Memory.find(ptr).readJsonObject();
     <% } -%>
   <% } else if (isUtf8Encoded(imp.output)) { -%>
     return Memory.find(ptr).readString();
-  <% } else if (imp.output.type === 'string') { -%>
+  <% } else if (isString(imp.output)) { -%>
     return Memory.find(ptr).readString();
   <% } else { -%>
     return Memory.find(ptr).readBytes();

--- a/tests/schemas/fruit.yaml
+++ b/tests/schemas/fruit.yaml
@@ -47,10 +47,10 @@ exports:
     codeSamples:
     - lang: typescript
       source: |
-        return { ghost: GhostGang.inky, aBoolean: true, aString: "okay", anInt: 123 }
+        return input
     input:
       contentType: application/json
-      $ref: "#/components/schemas/Fruit"
+      $ref: "#/components/schemas/ComplexObject"
     output:
       contentType: application/json
       $ref: "#/components/schemas/ComplexObject"
@@ -109,12 +109,22 @@ components:
       - clyde
       description: A set of all the enemies of pac-man
     ComplexObject:
+      required:
+        - arrayOfDate
       properties:
         arrayOfDate:
           type: array
           items:
             type: string
             format: date-time
+        arrayOfEnum:
+          type: array
+          items:
+            "$ref": "#/components/schemas/GhostGang"
+        arrayOfObjects:
+          type: array
+          items:
+            "$ref": "#/components/schemas/WriteParams"
         ghost:
           "$ref": "#/components/schemas/GhostGang"
           description: I can override the description for the property here
@@ -138,4 +148,34 @@ components:
         writeParams:
           "$ref": "#/components/schemas/WriteParams"
           nullable: true
+        aStringMap:
+          type: string
+          additionalProperties:
+            type: string
+        aWriteParamMap:
+          type: string
+          additionalProperties:
+            "$ref": "#/components/schemas/WriteParams"
+        aNullableWriteParamMap:
+          type: string
+          nullable: true
+          additionalProperties:
+            "$ref": "#/components/schemas/WriteParams"
+        aBuffer:
+          type: buffer
+          nullable: true
+        aMapOfDateArrays:
+          description: a string map
+          additionalProperties:
+            items:
+              type: string
+              format: date-time
+        aMapOfArraysOfMapsOfNullableDates:
+          description: a deep map
+          additionalProperties:
+            items:
+              additionalProperties:
+                nullable: true
+                type: string
+                format: date-time
       description: A complex json object


### PR DESCRIPTION
See https://github.com/dylibso/xtp-bindgen/pull/18

This refactor should serve as the basis for how we change the other bindgens. I've kept it backwards compatible but once the changes are rolled out everywhere, we should trim unused properties and features.

Note we have removed all code that references XTP schema type directly like:

* type
* format
* items
* $ref
* additionalProperties

Also note that coincidentally, this implements https://github.com/dylibso/xtp-typescript-bindgen/pull/36
