### PR TITLE
Make sure npm install is run

### DIFF
--- a/template/prepare.sh
+++ b/template/prepare.sh
@@ -84,3 +84,4 @@ if ! command_exists extism-js; then
   exit 1
 fi
 
+npm install

--- a/template/xtp.toml.ejs
+++ b/template/xtp.toml.ejs
@@ -9,10 +9,10 @@ name = "<%- project.name %>"
 
 [scripts]
 # xtp plugin build runs this script to generate the wasm file
-build = "sh prepare.sh && npm run build"
+build = "bash prepare.sh && npm run build"
 
 # xtp plugin init runs this script to format the code
 format = "npm run format"
 
 # xtp plugin init runs this script before running the format script
-prepare = "sh prepare.sh && npm install"
+prepare = "bash prepare.sh"


### PR DESCRIPTION
This is a temporary fix, but this ensures that npm install is run
preventing confusing errors like "this is not the typescript compiler
you were looking for" and other half-missing deps
